### PR TITLE
Adopt Swift result type

### DIFF
--- a/Tests/Extensions.swift
+++ b/Tests/Extensions.swift
@@ -98,3 +98,20 @@ extension Future {
         }
     }
 }
+
+
+extension Result {
+    var value: Success? {
+        switch self {
+        case let .success(value): return value
+        case .failure: return nil
+        }
+    }
+
+    var error: Failure? {
+        switch self {
+        case .success: return nil
+        case let .failure(error): return error
+        }
+    }
+}

--- a/Tests/FutureTests.swift
+++ b/Tests/FutureTests.swift
@@ -374,19 +374,23 @@ class SchedulersTests: XCTestCase {
 }
 
 class MapErrorTest: XCTestCase {
+    struct NewError: Swift.Error, Hashable {
+        let id: String
+    }
+
     func testMapError() {
         // GIVEN failed future
         let future = Future<Int, MyError>(error: .e1)
 
         // WHEN mapping error
         let mapped = future.mapError { _ in
-            return "e1"
+            return NewError(id: "e1")
         }
 
         // EXPECT mapped future to return a new error
         let expectation = self.expectation()
         mapped.on(failure: { error in
-            XCTAssertEqual(mapped.error, "e1")
+            XCTAssertEqual(mapped.error, NewError(id: "e1"))
             expectation.fulfill()
         })
 
@@ -399,14 +403,14 @@ class MapErrorTest: XCTestCase {
 
         // WHEN recovering from error with a value
         let mapped = promise.future.mapError { _ in
-            return "e1"
+            return NewError(id: "e1")
         }
 
         DispatchQueue.global().async {
             promise.fail(error: .e1)
         }
 
-        XCTAssertEqual(mapped.wait().error, "e1")
+        XCTAssertEqual(mapped.wait().error, NewError(id: "e1"))
     }
 }
 


### PR DESCRIPTION
  - Replace custom Result type with the one from the Standard Library
  - Future now requires Error to conform to Swift.Error