### PR TITLE
updating swiftpm structure references

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,9 @@ let package = Package(
     products: [
         .library(name: "Future", targets: ["Future"])
     ],
+    dependencies: [],
     targets: [
-        .target(name: "Future", path: "Sources")
+        .target(name: "Future", dependencies: [], path: "Sources"),
+        .testTarget(name: "FutureTests", dependencies: ["Future"], path: "Tests")
     ]
 )


### PR DESCRIPTION
I went to try this on swift on Linux, since a cursory review made it look like it might work nicely. The swiftPM references were missing a bit to trigger the tests, so I wanted to offer this minor update back which helps (but doesn't fully) resolve it.

I wasn't sure why `Host` (which seems to be UIKit/IOS specific) was under the `Tests` directory, but when I removed then all the tests were able to run locally (and remotely). Shifting the tests down one more directory and updating the `path` reference in the testTarget would likely fully resolve this. I wanted to check and see if this update was of interest before making the relevant tweaks.

If you're game to support swift for linux with this, I might also recommend replacing arc4random with some of the unified random number generators (such as https://developer.apple.com/documentation/swift/randomnumbergenerator).